### PR TITLE
1.3.1 - add cache no-store attribute to the PDF generation request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 1.3.1 - 06/11/23
+- Add cache no-store attribute to the PDF generation request
+
 ### 1.3.0 - 01/11/23
 - Add default footer setting
 - Add text_before_payment_link setting

--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://www.linknacional.com/wordpress/plugins/
 Tags: woocommerce, invoice, payment
 Requires at least: 5.7
 Tested up to: 6.3
-Stable tag: 1.3.0
+Stable tag: 1.3.1
 Requires PHP: 7.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -63,6 +63,9 @@ The Invoice Payment for WooCommerce plugin is now live and working.
 3. See all generated invoices and their status.
 
 == Changelog ==
+
+= 1.3.1 =
+* add cache no-store attribute to the PDF generation request
 
 = 1.3.0 =
 * Add default footer setting

--- a/admin/js/wc-invoice-payment-admin.js
+++ b/admin/js/wc-invoice-payment-admin.js
@@ -92,7 +92,8 @@ function lkn_wcip_generate_invoice_pdf (invoiceId) {
     headers: {
       'content-type': 'application/json',
       'X-WP-Nonce': document.getElementById('wcip_rest_nonce').value
-    }
+    },
+    cache: 'no-store'
   })
     .then(res => {
       if (!res.ok) {

--- a/wc-invoice-payment.php
+++ b/wc-invoice-payment.php
@@ -15,7 +15,7 @@
  * Plugin Name:       Invoice Payment for WooCommerce
  * Plugin URI:        https://www.linknacional.com/wordpress/plugins/
  * Description:       Invoice payment generation and management for WooCommerce.
- * Version:           1.3.0
+ * Version:           1.3.1
  * Author:            Link Nacional
  * Author URI:        https://www.linknacional.com/
  * License:           GPL-2.0+
@@ -34,7 +34,7 @@ if ( ! defined('WPINC')) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define('WC_PAYMENT_INVOICE_VERSION', '1.3.0');
+define('WC_PAYMENT_INVOICE_VERSION', '1.3.1');
 define('WC_PAYMENT_INVOICE_TRANSLATION_PATH', plugin_dir_path(__FILE__) . 'languages/');
 define('WC_PAYMENT_INVOICE_ROOT_DIR', plugin_dir_path(__FILE__));
 define('WC_PAYMENT_INVOICE_ROOT_URL', plugin_dir_url(__FILE__));


### PR DESCRIPTION
## Changelog

- add cache no-store attribute to the PDF generation request

## Check
- [x] Update hardcoded version
- [x] Update README with notes
- [x] Update CHANGELOG
