### PR TITLE
2.3.0 Adição de hook para processar assinatura automaticamente

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
       uses: mathieudutour/github-tag-action@v6.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        custom_tag: '2.2.1'
+        custom_tag: '2.3.0'
 
     # Generate new release
     - name: Generate new Release

--- a/Admin/LknWcipListTable.php
+++ b/Admin/LknWcipListTable.php
@@ -1656,7 +1656,7 @@ final class LknWcipListTable {
                             if ('generate_invoice_event' === $hook || 'lkn_wcip_cron_hook' === $hook) {
                                 // Verifique se os argumentos do evento contêm o ID da ordem que você deseja remover
                                 $event_args = $event['args'];
-                                if (is_array($event_args) && in_array($invoice_id, $event_args, true)) {
+                                if (is_array($event_args) && in_array($invoice_id, $event_args)) {
                                     // Remova o evento do WP Cron
                                     wp_unschedule_event($timestamp, $hook, $event_args);
                                 }

--- a/Admin/WcPaymentInvoiceAdmin.php
+++ b/Admin/WcPaymentInvoiceAdmin.php
@@ -717,7 +717,7 @@ final class WcPaymentInvoiceAdmin {
                             <div class="tooltip">
                                 <span>?</span>
                                 <span class="tooltiptext">
-                                    <?php esc_attr_e('If the multiple payments option is selected, automatic recurring payments will be disabled.', 'wc-invoice-payment'); ?>
+                                    <?php esc_attr_e('To automate charges, choose a compatible payment method (e.g., Cielo Pro Plugin). If multiple payments are selected, the charge will not be automatic.', 'wc-invoice-payment'); ?>
                                 </span>
                             </div>
                         </label>
@@ -836,7 +836,7 @@ final class WcPaymentInvoiceAdmin {
                                 <div class="tooltip">
                                     <span>?</span>
                                     <span class="tooltiptext">
-                                        <?php esc_attr_e('If the assigned user is a guest, automatic recurring payments will be disabled.', 'wc-invoice-payment'); ?>
+                                        <?php esc_attr_e('Select a user to generate subscriptions. Guests cannot process automatic charges.', 'wc-invoice-payment'); ?>
                                     </span>
                                 </div>
                             </div>
@@ -1373,7 +1373,7 @@ final class WcPaymentInvoiceAdmin {
                             <div class="tooltip">
                                 <span>?</span>
                                 <span class="tooltiptext">
-                                    <?php esc_attr_e('If the multiple payments option is selected, automatic recurring payments will be disabled.', 'wc-invoice-payment'); ?>
+                                    <?php esc_attr_e('To automate charges, choose a compatible payment method (e.g., Cielo Pro Plugin). If multiple payments are selected, the charge will not be automatic.', 'wc-invoice-payment'); ?>
                                 </span>
                             </div>
                         </label>
@@ -1492,7 +1492,7 @@ final class WcPaymentInvoiceAdmin {
                                 <div class="tooltip">
                                     <span>?</span>
                                     <span class="tooltiptext">
-                                        <?php esc_attr_e('If the assigned user is a guest, automatic recurring payments will be disabled.', 'wc-invoice-payment'); ?>
+                                        <?php esc_attr_e('Select a user to generate subscriptions. Guests cannot process automatic charges.', 'wc-invoice-payment'); ?>
                                     </span>
                                 </div>
                             </div>
@@ -2043,7 +2043,7 @@ final class WcPaymentInvoiceAdmin {
                             <div class="tooltip">
                                 <span>?</span>
                                 <span class="tooltiptext">
-                                    <?php esc_attr_e('If the multiple payments option is selected, automatic recurring payments will be disabled.', 'wc-invoice-payment'); ?>
+                                    <?php esc_attr_e('To automate charges, choose a compatible payment method (e.g., Cielo Pro Plugin). If multiple payments are selected, the charge will not be automatic.', 'wc-invoice-payment'); ?>
                                 </span>
                             </div>
                         </label>
@@ -2154,7 +2154,7 @@ final class WcPaymentInvoiceAdmin {
                                 <div class="tooltip">
                                     <span>?</span>
                                     <span class="tooltiptext">
-                                        <?php esc_attr_e('If the assigned user is a guest, automatic recurring payments will be disabled.', 'wc-invoice-payment'); ?>
+                                        <?php esc_attr_e('Select a user to generate subscriptions. Guests cannot process automatic charges.', 'wc-invoice-payment'); ?>
                                     </span>
                                 </div>
                             </div>

--- a/Admin/WcPaymentInvoiceAdmin.php
+++ b/Admin/WcPaymentInvoiceAdmin.php
@@ -424,10 +424,10 @@ final class WcPaymentInvoiceAdmin {
                                         type="checkbox"
                                         name="lkn_wcip_after_save_button_email_check"
                                         id="lkn_wcip_after_save_button_email_check"
-                                        <i
-                                    ></i><?php if ($email_verify) {
-                                        echo 'checked';
-                                    } ?>
+                                        <?php if ($email_verify) {
+                                            echo 'checked';
+                                        } ?>
+                                        <i></i>
                                     <?php esc_attr_e('Enable email verification on the invoice.', 'wc-invoice-payment'); ?>
 
                                     <div class="tooltip">
@@ -453,9 +453,10 @@ final class WcPaymentInvoiceAdmin {
                                         type="checkbox"
                                         class=""
                                         value="1"
-                                        ><?php if ($product_invoices) {
-                                        echo 'checked';
-                                    } ?>
+                                        <?php if ($product_invoices) {
+                                            echo 'checked';
+                                        } ?>
+                                        >
                                     <?php esc_attr_e('Create invoices for products', 'wc-invoice-payment') ?>
 
                                     <div class="tooltip">
@@ -822,10 +823,26 @@ final class WcPaymentInvoiceAdmin {
                         >
                     </div>
                     <div class="input-row-wrap">
-                        <label for="lkn_wcip_email_input"><?php esc_attr_e('Email', 'wc-invoice-payment'); ?></label>
-                        <select class="wc-customer-search" id="lkn_wcip_email_input" name="lkn_wcip_email" data-placeholder="Visitante" data-allow_clear="true">
+                        <label for="lkn_wcip_customer_input">
+                            <?php esc_attr_e('Customer', 'wc-invoice-payment'); ?>
+                            <a target="_blank" href="<?php echo esc_attr(admin_url('user-new.php')); ?>"><?php esc_attr_e('Create user', 'wc-invoice-payment'); ?></a>
+                        </label>
+                        <select class="wc-customer-search" id="lkn_wcip_customer_input" name="lkn_wcip_customer" data-placeholder="Visitante" data-allow_clear="true">
                             <option value="<?php echo esc_attr( $userId ); ?>" selected="selected"><?php echo esc_html( $userInfos ); ?></option>
                         </select>
+                    </div>
+                    <div class="input-row-wrap" id="lknWcipEmailInput" <?php echo (!empty($userId)) ? 'style="display: none;"' : ''; ?>>
+                        <label
+                            for="lkn_wcip_email_input"><?php esc_attr_e('Email', 'wc-invoice-payment'); ?></label>
+                        <input
+                            name="lkn_wcip_email"
+                            type="email"
+                            id="lkn_wcip_email_input"
+                            class="regular-text"
+                            required
+                            value="<?php echo esc_html($order->get_billing_email()); ?>"
+                            <?php echo esc_attr(!empty($userId) ? '' : 'required'); ?>
+                        >
                     </div>
                     <div class="input-row-wrap">
                         <label for="lkn_wcip_country_input">
@@ -1447,10 +1464,26 @@ final class WcPaymentInvoiceAdmin {
                         >
                     </div>
                     <div class="input-row-wrap">
-                        <label for="lkn_wcip_email_input"><?php esc_attr_e('Email', 'wc-invoice-payment'); ?></label>
-                        <select class="wc-customer-search" id="lkn_wcip_email_input" name="lkn_wcip_email" data-placeholder="Visitante" data-allow_clear="true">
+                        <label for="lkn_wcip_customer_input">
+                            <?php esc_attr_e('Customer', 'wc-invoice-payment'); ?>
+                            <a target="_blank" href="<?php echo esc_attr(admin_url('user-new.php')); ?>"><?php esc_attr_e('Create user', 'wc-invoice-payment'); ?></a>
+                        </label>
+                        <select class="wc-customer-search" id="lkn_wcip_customer_input" name="lkn_wcip_customer" data-placeholder="Visitante" data-allow_clear="true">
                             <option value="<?php echo esc_attr( $userId ); ?>" selected="selected"><?php echo esc_html( $userInfos ); ?></option>
                         </select>
+                    </div>
+                    <div class="input-row-wrap" id="lknWcipEmailInput" <?php echo (!empty($userId)) ? 'style="display: none;"' : ''; ?>>
+                        <label
+                            for="lkn_wcip_email_input"><?php esc_attr_e('Email', 'wc-invoice-payment'); ?></label>
+                        <input
+                            name="lkn_wcip_email"
+                            type="email"
+                            id="lkn_wcip_email_input"
+                            class="regular-text"
+                            required
+                            value="<?php echo esc_html($order->get_billing_email()); ?>"
+                            <?php echo esc_attr(!empty($userId) ? '' : 'required'); ?>
+                        >
                     </div>
                     <div class="input-row-wrap">
                         <label for="lkn_wcip_country_input">
@@ -2078,12 +2111,23 @@ final class WcPaymentInvoiceAdmin {
                         >
                     </div>
                     <div class="input-row-wrap">
-                        <label for="lkn_wcip_email_input">
-                            <?php esc_attr_e('Email', 'wc-invoice-payment'); ?>
+                        <label for="lkn_wcip_customer_input">
+                            <?php esc_attr_e('Customer', 'wc-invoice-payment'); ?>
                             <a target="_blank" href="<?php echo esc_attr(admin_url('user-new.php')); ?>"><?php esc_attr_e('Create user', 'wc-invoice-payment'); ?></a>
                         </label>
-                        <select class="wc-customer-search" id="lkn_wcip_email_input" name="lkn_wcip_email" data-placeholder="Visitante" data-allow_clear="true">
+                        <select class="wc-customer-search" id="lkn_wcip_customer_input" name="lkn_wcip_customer" data-placeholder="Visitante" data-allow_clear="true">
                         </select>
+                    </div>
+                    <div class="input-row-wrap" id="lknWcipEmailInput">
+                        <label
+                            for="lkn_wcip_email_input"><?php esc_attr_e('Email', 'wc-invoice-payment'); ?></label>
+                        <input
+                            name="lkn_wcip_email"
+                            type="email"
+                            id="lkn_wcip_email_input"
+                            class="regular-text"
+                            required
+                        >
                     </div>
                     <div class="input-row-wrap">
                         <label for="lkn_wcip_country_input">
@@ -2357,7 +2401,8 @@ final class WcPaymentInvoiceAdmin {
                 $name = sanitize_text_field(wp_unslash($_POST['lkn_wcip_name']));
                 $firstName = explode(' ', $name)[0];
                 $lastname = substr(strstr($name, ' '), 1);
-                $userId = isset($_POST['lkn_wcip_email']) ? sanitize_text_field(wp_unslash($_POST['lkn_wcip_email'])) : '';
+                $userId = isset($_POST['lkn_wcip_customer']) ? sanitize_text_field(wp_unslash($_POST['lkn_wcip_customer'])) : '';
+                $email = sanitize_email(wp_unslash($_POST['lkn_wcip_email']));
                 $expDate = sanitize_text_field(wp_unslash($_POST['lkn_wcip_exp_date']));
                 $iniDate = new DateTime();
                 $extraData = sanitize_text_field(wp_unslash($_POST['lkn_wcip_extra_data']));
@@ -2404,6 +2449,8 @@ final class WcPaymentInvoiceAdmin {
                         $order->set_customer_id($userId);
                     }
                 }
+
+                $order->set_billing_email($email);
                 $order->set_billing_first_name($firstName);
                 $order->set_billing_last_name($lastname);
                 $order->set_payment_method($paymentMethod);
@@ -2533,7 +2580,8 @@ final class WcPaymentInvoiceAdmin {
                 $country = sanitize_text_field(wp_unslash($_POST['lkn_wcip_country']));
                 $firstName = explode(' ', $name)[0];
                 $lastname = substr(strstr($name, ' '), 1);
-                $userId = isset($_POST['lkn_wcip_email']) ? sanitize_text_field(wp_unslash($_POST['lkn_wcip_email'])) : '';
+                $userId = isset($_POST['lkn_wcip_customer']) ? sanitize_text_field(wp_unslash($_POST['lkn_wcip_customer'])) : '';
+                $email = sanitize_email(wp_unslash($_POST['lkn_wcip_email']));
                 $expDate = sanitize_text_field(wp_unslash($_POST['lkn_wcip_exp_date']));
                 $pdfTemplateId = sanitize_text_field(wp_unslash($_POST['lkn_wcip_select_invoice_template']));
                 $pdfLanguage = sanitize_text_field(wp_unslash($_POST['lkn_wcip_select_invoice_language']));
@@ -2570,9 +2618,9 @@ final class WcPaymentInvoiceAdmin {
                     }
                 }else {
                     $order->set_customer_id(0);
-                    $order->set_billing_email('');
                 }
 
+                $order->set_billing_email($email);
                 $order->set_billing_country($country);
                 $order->set_billing_first_name($firstName);
                 $order->set_billing_last_name($lastname);
@@ -2693,7 +2741,8 @@ final class WcPaymentInvoiceAdmin {
                 $country = sanitize_text_field(wp_unslash($_POST['lkn_wcip_country']));
                 $firstName = explode(' ', $name)[0];
                 $lastname = substr(strstr($name, ' '), 1);
-                $userId = isset($_POST['lkn_wcip_email']) ? sanitize_text_field(wp_unslash($_POST['lkn_wcip_email'])) : '';
+                $userId = isset($_POST['lkn_wcip_customer']) ? sanitize_text_field(wp_unslash($_POST['lkn_wcip_customer'])) : '';
+                $email = sanitize_email(wp_unslash($_POST['lkn_wcip_email']));
                 $expDate = sanitize_text_field(wp_unslash($_POST['lkn_wcip_exp_date']));
                 $pdfTemplateId = sanitize_text_field(wp_unslash($_POST['lkn_wcip_select_invoice_template']));
                 $pdfLanguage = sanitize_text_field(wp_unslash($_POST['lkn_wcip_select_invoice_language']));
@@ -2729,9 +2778,9 @@ final class WcPaymentInvoiceAdmin {
                     }
                 }else {
                     $order->set_customer_id(0);
-                    $order->set_billing_email('');
                 }
 
+                $order->set_billing_email($email);
                 $order->set_billing_country($country);
                 $order->set_billing_first_name($firstName);
                 $order->set_billing_last_name($lastname);

--- a/Admin/WcPaymentInvoiceAdmin.php
+++ b/Admin/WcPaymentInvoiceAdmin.php
@@ -1158,7 +1158,7 @@ final class WcPaymentInvoiceAdmin {
                     if ('generate_invoice_event' === $hook) {
                         // Verifique se os argumentos do evento contêm o invoiceId
                         $event_args = $event['args'];
-                        if (is_array($event_args) && in_array($invoice_id, $event_args, true)) {
+                        if (is_array($event_args) && in_array($invoice_id, $event_args)) {
                             // O invoiceId está agendado, então retorne verdadeiro
                             return true;
                         }
@@ -2151,7 +2151,7 @@ final class WcPaymentInvoiceAdmin {
                             type="checkbox"
                             name="lkn_wcip_subscription_product"
                             id="lkn_wcip_subscription_product"
-                            ><?php echo esc_attr($invoiceChecked) ?>
+                            <?php echo esc_attr($invoiceChecked) ?>>
                         <?php esc_attr_e('Subscription', 'wc-invoice-payment'); ?>
                     </label>
                     <div class="tooltip">
@@ -2210,8 +2210,6 @@ final class WcPaymentInvoiceAdmin {
                 'id' => 'lkn_wcip_subscription_limit',
                 'name' => 'lkn_wcip_subscription_limit',
                 'label' => __('Subscription limit', 'wc-invoice-payment'),
-                'desc_tip' => 'true',
-                'description' => __('Set a limit for the number of invoices that will be generated for the subscription, by default,  there is no limit.', 'wc-invoice-payment'),
                 'value' => 0,
                 'type' => 'number',
                 'custom_attributes' => array(
@@ -2221,6 +2219,12 @@ final class WcPaymentInvoiceAdmin {
             )
         );
         ?>
+            <div class="tooltip" id="subscriptionLimitTooltip">
+                <span>?</span>
+                <span class="tooltiptext">
+                    <?php esc_attr_e('Set a limit for the number of invoices that will be generated for the subscription, by default,  there is no limit.', 'wc-invoice-payment'); ?>
+                </span>
+            </div>
             </div>
             <script>
                 //Valida se a checkbox de assinatura está ativada para mostrar campos
@@ -2427,7 +2431,7 @@ final class WcPaymentInvoiceAdmin {
                 //Chama a função que configura o evento cron
                 if ($isSubscription) {
                     $subscription_class = new WcPaymentInvoiceSubscription();
-                    $subscription_class->validate_product($orderId);
+                    $subscription_class->validate_product($orderId, true);
                 }
 
                 $invoiceList = get_option('lkn_wcip_invoices');
@@ -2794,7 +2798,7 @@ final class WcPaymentInvoiceAdmin {
                             if ("generate_invoice_event" === $hook || 'lkn_wcip_cron_hook' === $hook) {
                                 // Verifique se os argumentos do evento contêm o ID da ordem que você deseja remover
                                 $event_args = $event['args'];
-                                if (is_array($event_args) && in_array($invoiceDelete[0], $event_args, true)) {
+                                if (is_array($event_args) && in_array($invoiceDelete[0], $event_args)) {
                                     // Remova o evento do WP Cron
                                     wp_unschedule_event($timestamp, $hook, $event_args);
                                 }

--- a/Admin/WcPaymentInvoiceAdmin.php
+++ b/Admin/WcPaymentInvoiceAdmin.php
@@ -12,8 +12,8 @@ use DateTime;
 use LknWc\WcInvoicePayment\Admin\LknWcipListTable;
 use LknWc\WcInvoicePayment\Admin\WcPaymentInvoicePdfTemplates;
 use LknWc\WcInvoicePayment\Includes\WcPaymentInvoiceSubscription;
-use WC_Product;
 use WC_Customer;
+use WC_Product;
 /**
  * The admin-specific functionality of the plugin.
  *
@@ -712,8 +712,15 @@ final class WcPaymentInvoiceAdmin {
                         </select>
                     </div>
                     <div class="input-row-wrap">
-                        <label
-                            for="lkn_wcip_default_payment_method_input"><?php esc_attr_e('Default payment method', 'wc-invoice-payment'); ?></label>
+                        <label for="lkn_wcip_default_payment_method_input">
+                            <?php esc_attr_e('Default payment method', 'wc-invoice-payment'); ?>
+                            <div class="tooltip">
+                                <span>?</span>
+                                <span class="tooltiptext">
+                                    <?php esc_attr_e('If the multiple payments option is selected, automatic recurring payments will be disabled.', 'wc-invoice-payment'); ?>
+                                </span>
+                            </div>
+                        </label>
                         <select
                             name="lkn_wcip_default_payment_method"
                             id="lkn_wcip_default_payment_method_input"
@@ -824,7 +831,15 @@ final class WcPaymentInvoiceAdmin {
                     </div>
                     <div class="input-row-wrap">
                         <label for="lkn_wcip_customer_input">
-                            <?php esc_attr_e('Customer', 'wc-invoice-payment'); ?>
+                            <div>
+                                <?php esc_attr_e('Customer', 'wc-invoice-payment'); ?>
+                                <div class="tooltip">
+                                    <span>?</span>
+                                    <span class="tooltiptext">
+                                        <?php esc_attr_e('If the assigned user is a guest, automatic recurring payments will be disabled.', 'wc-invoice-payment'); ?>
+                                    </span>
+                                </div>
+                            </div>
                             <a target="_blank" href="<?php echo esc_attr(admin_url('user-new.php')); ?>"><?php esc_attr_e('Create user', 'wc-invoice-payment'); ?></a>
                         </label>
                         <select class="wc-customer-search" id="lkn_wcip_customer_input" name="lkn_wcip_customer" data-placeholder="Visitante" data-allow_clear="true">
@@ -1353,8 +1368,15 @@ final class WcPaymentInvoiceAdmin {
                         </select>
                     </div>
                     <div class="input-row-wrap">
-                        <label
-                            for="lkn_wcip_default_payment_method_input"><?php esc_attr_e('Default payment method', 'wc-invoice-payment'); ?></label>
+                        <label for="lkn_wcip_default_payment_method_input">
+                            <?php esc_attr_e('Default payment method', 'wc-invoice-payment'); ?>
+                            <div class="tooltip">
+                                <span>?</span>
+                                <span class="tooltiptext">
+                                    <?php esc_attr_e('If the multiple payments option is selected, automatic recurring payments will be disabled.', 'wc-invoice-payment'); ?>
+                                </span>
+                            </div>
+                        </label>
                         <select
                             name="lkn_wcip_default_payment_method"
                             id="lkn_wcip_default_payment_method_input"
@@ -1465,7 +1487,15 @@ final class WcPaymentInvoiceAdmin {
                     </div>
                     <div class="input-row-wrap">
                         <label for="lkn_wcip_customer_input">
-                            <?php esc_attr_e('Customer', 'wc-invoice-payment'); ?>
+                            <div>
+                                <?php esc_attr_e('Customer', 'wc-invoice-payment'); ?>
+                                <div class="tooltip">
+                                    <span>?</span>
+                                    <span class="tooltiptext">
+                                        <?php esc_attr_e('If the assigned user is a guest, automatic recurring payments will be disabled.', 'wc-invoice-payment'); ?>
+                                    </span>
+                                </div>
+                            </div>
                             <a target="_blank" href="<?php echo esc_attr(admin_url('user-new.php')); ?>"><?php esc_attr_e('Create user', 'wc-invoice-payment'); ?></a>
                         </label>
                         <select class="wc-customer-search" id="lkn_wcip_customer_input" name="lkn_wcip_customer" data-placeholder="Visitante" data-allow_clear="true">
@@ -2008,8 +2038,15 @@ final class WcPaymentInvoiceAdmin {
                         </select>
                     </div>
                     <div class="input-row-wrap">
-                        <label
-                            for="lkn_wcip_default_payment_method_input"><?php esc_attr_e('Default payment method', 'wc-invoice-payment'); ?></label>
+                        <label for="lkn_wcip_default_payment_method_input">
+                            <?php esc_attr_e('Default payment method', 'wc-invoice-payment'); ?>
+                            <div class="tooltip">
+                                <span>?</span>
+                                <span class="tooltiptext">
+                                    <?php esc_attr_e('If the multiple payments option is selected, automatic recurring payments will be disabled.', 'wc-invoice-payment'); ?>
+                                </span>
+                            </div>
+                        </label>
                         <select
                             name="lkn_wcip_default_payment_method"
                             id="lkn_wcip_default_payment_method_input"
@@ -2112,7 +2149,15 @@ final class WcPaymentInvoiceAdmin {
                     </div>
                     <div class="input-row-wrap">
                         <label for="lkn_wcip_customer_input">
-                            <?php esc_attr_e('Customer', 'wc-invoice-payment'); ?>
+                            <div>
+                                <?php esc_attr_e('Customer', 'wc-invoice-payment'); ?>
+                                <div class="tooltip">
+                                    <span>?</span>
+                                    <span class="tooltiptext">
+                                        <?php esc_attr_e('If the assigned user is a guest, automatic recurring payments will be disabled.', 'wc-invoice-payment'); ?>
+                                    </span>
+                                </div>
+                            </div>
                             <a target="_blank" href="<?php echo esc_attr(admin_url('user-new.php')); ?>"><?php esc_attr_e('Create user', 'wc-invoice-payment'); ?></a>
                         </label>
                         <select class="wc-customer-search" id="lkn_wcip_customer_input" name="lkn_wcip_customer" data-placeholder="Visitante" data-allow_clear="true">

--- a/Admin/WcPaymentInvoiceAdmin.php
+++ b/Admin/WcPaymentInvoiceAdmin.php
@@ -13,7 +13,7 @@ use LknWc\WcInvoicePayment\Admin\LknWcipListTable;
 use LknWc\WcInvoicePayment\Admin\WcPaymentInvoicePdfTemplates;
 use LknWc\WcInvoicePayment\Includes\WcPaymentInvoiceSubscription;
 use WC_Product;
-
+use WC_Customer;
 /**
  * The admin-specific functionality of the plugin.
  *
@@ -155,7 +155,7 @@ final class WcPaymentInvoiceAdmin {
             || 'admin_page_edit-subscription' === $hook
             || 'wc-invoice-payment_page_wc-subscription-payment' === $hook
         ) {
-            wp_enqueue_script($this->plugin_name . '-admin-js', plugin_dir_url(__FILE__) . 'js/wc-invoice-payment-admin.js', array('wp-i18n'), $this->version, false);
+            wp_enqueue_script($this->plugin_name . '-admin-js', plugin_dir_url(__FILE__) . 'js/wc-invoice-payment-admin.js', array('wp-i18n', 'jquery'), $this->version, false);
             wp_set_script_translations($this->plugin_name . '-admin-js', 'wc-invoice-payment', WC_PAYMENT_INVOICE_TRANSLATION_PATH);
             wp_localize_script(
                 $this->plugin_name . '-admin-js',
@@ -571,6 +571,8 @@ final class WcPaymentInvoiceAdmin {
 
         wp_enqueue_editor();
         wp_create_nonce('wp_rest');
+        wp_enqueue_script( 'wc-enhanced-select' );
+        wp_enqueue_style( 'woocommerce_admin_styles' );
 
         $invoiceId = sanitize_text_field(wp_unslash($_GET['invoice']));
 
@@ -590,7 +592,21 @@ final class WcPaymentInvoiceAdmin {
 
         $c = 0;
         $order = wc_get_order($invoiceId);
-        if ($order->get_meta('lkn_subscription_id')) {
+        if ( $order->get_user_id() ) {
+            $userId = absint( $order->get_user_id() );
+            $user = get_userdata( $userId );
+            $userInfos = sprintf(
+                '%s (#%d – %s)',
+                $user->display_name, // Nome completo do usuário
+                $userId, // ID do usuário
+                $user->user_email // Email do usuário
+            );
+        }else{
+            $userId = '';
+            $userInfos = '';
+        }
+
+        if($order->get_meta('lkn_subscription_id')){
             $subscription_id = $order->get_meta('lkn_subscription_id');
         }
         $items = $order->get_items();
@@ -806,16 +822,10 @@ final class WcPaymentInvoiceAdmin {
                         >
                     </div>
                     <div class="input-row-wrap">
-                        <label
-                            for="lkn_wcip_email_input"><?php esc_attr_e('Email', 'wc-invoice-payment'); ?></label>
-                        <input
-                            name="lkn_wcip_email"
-                            type="email"
-                            id="lkn_wcip_email_input"
-                            class="regular-text"
-                            required
-                            value="<?php echo esc_html($order->get_billing_email()); ?>"
-                        >
+                        <label for="lkn_wcip_email_input"><?php esc_attr_e('Email', 'wc-invoice-payment'); ?></label>
+                        <select class="wc-customer-search" id="lkn_wcip_email_input" name="lkn_wcip_email" data-placeholder="Visitante" data-allow_clear="true">
+                            <option value="<?php echo esc_attr( $userId ); ?>" selected="selected"><?php echo esc_html( $userInfos ); ?></option>
+                        </select>
                     </div>
                     <div class="input-row-wrap">
                         <label for="lkn_wcip_country_input">
@@ -1164,6 +1174,9 @@ final class WcPaymentInvoiceAdmin {
      * Render html page for subscription edit.
      */
     public function render_edit_subscription_page(): void {
+        wp_enqueue_script( 'wc-enhanced-select' );
+        wp_enqueue_style( 'woocommerce_admin_styles' );
+        
         wp_enqueue_script($this->plugin_name . '-edit', plugin_dir_url(__FILE__) . 'js/wc-invoice-payment-invoice-edit.js', array(), $this->version, 'all');
         wp_enqueue_style($this->plugin_name . '-edit', plugin_dir_url(__FILE__) . 'css/wc-invoice-payment-invoice-edit.css', array(), $this->version, 'all');
 
@@ -1195,6 +1208,20 @@ final class WcPaymentInvoiceAdmin {
 
         $c = 0;
         $order = wc_get_order($invoiceId);
+
+        if ( $order->get_user_id() ) {
+            $userId = absint( $order->get_user_id() );
+            $user = get_userdata( $userId );
+            $userInfos = sprintf(
+                '%s (#%d – %s)',
+                $user->display_name, // Nome completo do usuário
+                $userId, // ID do usuário
+                $user->user_email // Email do usuário
+            );
+        }else{
+            $userId = '';
+            $userInfos = '';
+        }
 
         $args = array(
             'meta_key' => 'lkn_subscription_id',
@@ -1420,16 +1447,10 @@ final class WcPaymentInvoiceAdmin {
                         >
                     </div>
                     <div class="input-row-wrap">
-                        <label
-                            for="lkn_wcip_email_input"><?php esc_attr_e('Email', 'wc-invoice-payment'); ?></label>
-                        <input
-                            name="lkn_wcip_email"
-                            type="email"
-                            id="lkn_wcip_email_input"
-                            class="regular-text"
-                            required
-                            value="<?php echo esc_html($order->get_billing_email()); ?>"
-                        >
+                        <label for="lkn_wcip_email_input"><?php esc_attr_e('Email', 'wc-invoice-payment'); ?></label>
+                        <select class="wc-customer-search" id="lkn_wcip_email_input" name="lkn_wcip_email" data-placeholder="Visitante" data-allow_clear="true">
+                            <option value="<?php echo esc_attr( $userId ); ?>" selected="selected"><?php echo esc_html( $userInfos ); ?></option>
+                        </select>
                     </div>
                     <div class="input-row-wrap">
                         <label for="lkn_wcip_country_input">
@@ -1847,6 +1868,8 @@ final class WcPaymentInvoiceAdmin {
         }
 
         wp_enqueue_editor();
+        wp_enqueue_script( 'wc-enhanced-select' );
+        wp_enqueue_style( 'woocommerce_admin_styles' );
 
         $currencies = get_woocommerce_currencies();
         $currency_codes = array_keys($currencies);
@@ -2055,15 +2078,12 @@ final class WcPaymentInvoiceAdmin {
                         >
                     </div>
                     <div class="input-row-wrap">
-                        <label
-                            for="lkn_wcip_email_input"><?php esc_attr_e('Email', 'wc-invoice-payment'); ?></label>
-                        <input
-                            name="lkn_wcip_email"
-                            type="email"
-                            id="lkn_wcip_email_input"
-                            class="regular-text"
-                            required
-                        >
+                        <label for="lkn_wcip_email_input">
+                            <?php esc_attr_e('Email', 'wc-invoice-payment'); ?>
+                            <a target="_blank" href="<?php echo esc_attr(admin_url('user-new.php')); ?>"><?php esc_attr_e('Create user', 'wc-invoice-payment'); ?></a>
+                        </label>
+                        <select class="wc-customer-search" id="lkn_wcip_email_input" name="lkn_wcip_email" data-placeholder="Visitante" data-allow_clear="true">
+                        </select>
                     </div>
                     <div class="input-row-wrap">
                         <label for="lkn_wcip_country_input">
@@ -2134,6 +2154,12 @@ final class WcPaymentInvoiceAdmin {
                             ><?php echo esc_attr($invoiceChecked) ?>
                         <?php esc_attr_e('Subscription', 'wc-invoice-payment'); ?>
                     </label>
+                    <div class="tooltip">
+                        <span>?</span>
+                        <span class="tooltiptext">
+                            <?php esc_attr_e('Feature available for registered user.', 'wc-invoice-payment'); ?>
+                        </span>
+                    </div>
                 </div>
                 <div
                     class="input-row-wrap"
@@ -2327,7 +2353,7 @@ final class WcPaymentInvoiceAdmin {
                 $name = sanitize_text_field(wp_unslash($_POST['lkn_wcip_name']));
                 $firstName = explode(' ', $name)[0];
                 $lastname = substr(strstr($name, ' '), 1);
-                $email = sanitize_email(wp_unslash($_POST['lkn_wcip_email']));
+                $userId = isset($_POST['lkn_wcip_email']) ? sanitize_text_field(wp_unslash($_POST['lkn_wcip_email'])) : '';
                 $expDate = sanitize_text_field(wp_unslash($_POST['lkn_wcip_exp_date']));
                 $iniDate = new DateTime();
                 $extraData = sanitize_text_field(wp_unslash($_POST['lkn_wcip_extra_data']));
@@ -2366,7 +2392,14 @@ final class WcPaymentInvoiceAdmin {
                 }
 
                 // Set all order attributes
-                $order->set_billing_email($email);
+                if (!empty($userId)) {
+                    $user = get_user_by('ID', $userId);
+                    if ($user) {
+                        $email = $user->user_email;
+                        $order->set_billing_email($email);
+                        $order->set_customer_id($userId);
+                    }
+                }
                 $order->set_billing_first_name($firstName);
                 $order->set_billing_last_name($lastname);
                 $order->set_payment_method($paymentMethod);
@@ -2496,7 +2529,7 @@ final class WcPaymentInvoiceAdmin {
                 $country = sanitize_text_field(wp_unslash($_POST['lkn_wcip_country']));
                 $firstName = explode(' ', $name)[0];
                 $lastname = substr(strstr($name, ' '), 1);
-                $email = sanitize_email(wp_unslash($_POST['lkn_wcip_email']));
+                $userId = isset($_POST['lkn_wcip_email']) ? sanitize_text_field(wp_unslash($_POST['lkn_wcip_email'])) : '';
                 $expDate = sanitize_text_field(wp_unslash($_POST['lkn_wcip_exp_date']));
                 $pdfTemplateId = sanitize_text_field(wp_unslash($_POST['lkn_wcip_select_invoice_template']));
                 $pdfLanguage = sanitize_text_field(wp_unslash($_POST['lkn_wcip_select_invoice_language']));
@@ -2523,8 +2556,20 @@ final class WcPaymentInvoiceAdmin {
                 }
 
                 // Set all order attributes
+
+                if (!empty($userId)) {
+                    $user = get_user_by('ID', $userId);
+                    if ($user) {
+                        $email = $user->user_email;
+                        $order->set_billing_email($email);
+                        $order->set_customer_id($userId);
+                    }
+                }else {
+                    $order->set_customer_id(0);
+                    $order->set_billing_email('');
+                }
+
                 $order->set_billing_country($country);
-                $order->set_billing_email($email);
                 $order->set_billing_first_name($firstName);
                 $order->set_billing_last_name($lastname);
                 $order->set_payment_method($paymentMethod);
@@ -2644,7 +2689,7 @@ final class WcPaymentInvoiceAdmin {
                 $country = sanitize_text_field(wp_unslash($_POST['lkn_wcip_country']));
                 $firstName = explode(' ', $name)[0];
                 $lastname = substr(strstr($name, ' '), 1);
-                $email = sanitize_email(wp_unslash($_POST['lkn_wcip_email']));
+                $userId = isset($_POST['lkn_wcip_email']) ? sanitize_text_field(wp_unslash($_POST['lkn_wcip_email'])) : '';
                 $expDate = sanitize_text_field(wp_unslash($_POST['lkn_wcip_exp_date']));
                 $pdfTemplateId = sanitize_text_field(wp_unslash($_POST['lkn_wcip_select_invoice_template']));
                 $pdfLanguage = sanitize_text_field(wp_unslash($_POST['lkn_wcip_select_invoice_language']));
@@ -2671,8 +2716,19 @@ final class WcPaymentInvoiceAdmin {
                 }
 
                 // Set all order attributes
+                if (!empty($userId)) {
+                    $user = get_user_by('ID', $userId);
+                    if ($user) {
+                        $email = $user->user_email;
+                        $order->set_billing_email($email);
+                        $order->set_customer_id($userId);
+                    }
+                }else {
+                    $order->set_customer_id(0);
+                    $order->set_billing_email('');
+                }
+
                 $order->set_billing_country($country);
-                $order->set_billing_email($email);
                 $order->set_billing_first_name($firstName);
                 $order->set_billing_last_name($lastname);
                 $order->set_payment_method($paymentMethod);

--- a/Admin/css/wc-invoice-payment-admin.css
+++ b/Admin/css/wc-invoice-payment-admin.css
@@ -396,6 +396,7 @@
 
 #select2-lkn_wcip_email_input-container{
 	border: 0px !important;
+	height: 100% !important;
 }
 
 .select2.select2-container.select2-container--default{

--- a/Admin/css/wc-invoice-payment-admin.css
+++ b/Admin/css/wc-invoice-payment-admin.css
@@ -280,7 +280,7 @@
 	display: flex;
 	flex-direction: row;
 	align-items: center;
-	gap: 17px;
+	gap: 6px;
 }
 
 #lkn-wcip-share-title {
@@ -380,4 +380,29 @@
 
 #lkn_wcip_subscription_interval_div_tip {
 	padding-left: 6px;
+}
+
+.select2-selection__placeholder{
+	color: rgb(0, 0, 0) !important;
+}
+
+.select2-selection__rendered{
+	box-shadow: 0 0 0 transparent;
+    border-radius: 4px;
+    border: 1px solid #8c8f94;
+    background-color: #fff;
+}
+
+
+#select2-lkn_wcip_email_input-container{
+	border: 0px !important;
+}
+
+.select2.select2-container.select2-container--default{
+	width: 350px !important;
+}
+
+label[for="lkn_wcip_email_input"] {
+	display: flex;
+	justify-content: space-between;
 }

--- a/Admin/css/wc-invoice-payment-admin.css
+++ b/Admin/css/wc-invoice-payment-admin.css
@@ -403,7 +403,7 @@
 	width: 350px !important;
 }
 
-label[for="lkn_wcip_email_input"] {
+label[for="lkn_wcip_customer_input"] {
 	display: flex;
 	justify-content: space-between;
 }

--- a/Admin/js/wc-invoice-payment-admin.js
+++ b/Admin/js/wc-invoice-payment-admin.js
@@ -353,21 +353,26 @@ jQuery(document).ready(function ($) {
   if(subscriptionInput){
     subscriptionInput.dispatchEvent(new Event("change"))
   }
+  
+  $('#lkn_wcip_customer_input').on('change', function() {
+      var selectedValue = $(this).val();
 
-  $('#lkn_wcip_email_input').on('change', function() {
-    var selectedValue = $(this).val();
-    if (!selectedValue) {
-      $('#lkn_wcip_subscription_product').prop('checked', false).prop('disabled', true);
-      $('#lkn_wcip_subscription_product').closest('label').css('opacity', '0.5');
-    } else {
-      $('#lkn_wcip_subscription_product').prop('disabled', false);
-      $('#lkn_wcip_subscription_product').closest('label').css('opacity', '1');
-    }
+      if (!selectedValue) {
+        $('#lkn_wcip_subscription_product').prop('checked', false).prop('disabled', true);
+        $('#lkn_wcip_subscription_product').closest('label').css('opacity', '0.5');
+        $('#lknWcipEmailInput').css('display', 'flex')
+        $('#lkn_wcip_email_input').prop('required', true)
+      } else {
+        $('#lkn_wcip_subscription_product').prop('disabled', false);
+        $('#lkn_wcip_subscription_product').closest('label').css('opacity', '1');
+        $('#lknWcipEmailInput').css('display', 'none')
+        $('#lkn_wcip_email_input').prop('required', false)
+      }
 
-    if(subscriptionInput){
-      subscriptionInput.dispatchEvent(new Event("change"))
-    }
-  });
+      if(subscriptionInput){
+        subscriptionInput.dispatchEvent(new Event("change"))
+      }
+    });
 
   $(".form-field").each(function () {
     var $field = $(this);

--- a/Admin/js/wc-invoice-payment-admin.js
+++ b/Admin/js/wc-invoice-payment-admin.js
@@ -353,7 +353,9 @@ jQuery(document).ready(function ($) {
   if(subscriptionInput){
     subscriptionInput.dispatchEvent(new Event("change"))
   }
-  
+  if(!$('#lkn_wcip_customer_input').val()){
+    $('#message').css('display', 'block')
+  }
   $('#lkn_wcip_customer_input').on('change', function() {
       var selectedValue = $(this).val();
 

--- a/Admin/js/wc-invoice-payment-admin.js
+++ b/Admin/js/wc-invoice-payment-admin.js
@@ -349,16 +349,34 @@ jQuery(document).ready(function ($) {
 jQuery(document).ready(function ($) {
   $('#lkn_wcip_subscription_product').prop('checked', false).prop('disabled', true);
   $('#lkn_wcip_subscription_product').closest('label').css('opacity', '0.5');
+  subscriptionInput = document.getElementById("lkn_wcip_subscription_product")
+  if(subscriptionInput){
+    subscriptionInput.dispatchEvent(new Event("change"))
+  }
 
   $('#lkn_wcip_email_input').on('change', function() {
     var selectedValue = $(this).val();
     if (!selectedValue) {
       $('#lkn_wcip_subscription_product').prop('checked', false).prop('disabled', true);
-      $('#lkn_wcip_subscription_product').change();
       $('#lkn_wcip_subscription_product').closest('label').css('opacity', '0.5');
     } else {
       $('#lkn_wcip_subscription_product').prop('disabled', false);
       $('#lkn_wcip_subscription_product').closest('label').css('opacity', '1');
+    }
+
+    if(subscriptionInput){
+      subscriptionInput.dispatchEvent(new Event("change"))
+    }
+  });
+
+  $(".form-field").each(function () {
+    var $field = $(this);
+    var $tooltip = $field.next(".tooltip");
+
+    if ($tooltip.length) {
+        $field.find("label").after($tooltip); 
+        $tooltip.css("margin-left", "4px");
+        $tooltip.css("margin-bottom", "4px");
     }
   });
 });

--- a/Admin/js/wc-invoice-payment-admin.js
+++ b/Admin/js/wc-invoice-payment-admin.js
@@ -344,3 +344,21 @@ jQuery(document).ready(function ($) {
     $(this).attr('title', $(this).attr('aria-label'))
   })
 })
+
+
+jQuery(document).ready(function ($) {
+  $('#lkn_wcip_subscription_product').prop('checked', false).prop('disabled', true);
+  $('#lkn_wcip_subscription_product').closest('label').css('opacity', '0.5');
+
+  $('#lkn_wcip_email_input').on('change', function() {
+    var selectedValue = $(this).val();
+    if (!selectedValue) {
+      $('#lkn_wcip_subscription_product').prop('checked', false).prop('disabled', true);
+      $('#lkn_wcip_subscription_product').change();
+      $('#lkn_wcip_subscription_product').closest('label').css('opacity', '0.5');
+    } else {
+      $('#lkn_wcip_subscription_product').prop('disabled', false);
+      $('#lkn_wcip_subscription_product').closest('label').css('opacity', '1');
+    }
+  });
+});

--- a/Admin/js/wc-invoice-payment-invoice-edit.js
+++ b/Admin/js/wc-invoice-payment-invoice-edit.js
@@ -38,4 +38,11 @@ jQuery(document).ready(function ($) {
 
     $link.attr('href', url.toString())
   })
+
+  if (window.location.search.includes("page=edit-subscription")) {
+    const removeUserButton = document.querySelector(".select2-selection__clear");
+    if (removeUserButton) {
+        removeUserButton.remove();
+    }
+  }
 })

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.3.0 - 14/02/2025
+* Adição de campo para pesquisar email do usuário;
+* Adição de hook para processar assinatura automaticamente;
+* Adição de função para forçar registro do cliente no checkout.
+
 # 2.2.1 - 31/01/2025
 * Correção de compatibilidade com o plugin "Payment Gateway Based Fees for WooCommerce";
 * Atualizando link da descrição do plugin.

--- a/Includes/WcPaymentInvoiceSubscription.php
+++ b/Includes/WcPaymentInvoiceSubscription.php
@@ -22,7 +22,7 @@ final class WcPaymentInvoiceSubscription {
                         if ('generate_invoice_event' === $hook) {
                             // Verifique se os argumentos do evento contêm o ID da ordem que você deseja remover
                             $event_args = $event['args'];
-                            if (is_array($event_args) && in_array($invoice_id, $event_args, true)) {
+                            if (is_array($event_args) && in_array($invoice_id, $event_args)) {
                                 // Remova o evento do WP Cron
                                 wp_unschedule_event($timestamp, $hook, $event_args);
                             }
@@ -167,7 +167,7 @@ final class WcPaymentInvoiceSubscription {
         }
     }
 
-    public function validate_product( $order_id ): void {
+    public function validate_product( $order_id, $manualSubscription = false ): void {
         if (gettype($order_id) == "object") {
             $order_id = $order_id->id;
         }
@@ -178,7 +178,7 @@ final class WcPaymentInvoiceSubscription {
         foreach ( $items as $item ) {
             $product_id = $item->get_product_id();
             $is_subscription_enabled = get_post_meta( $product_id, '_lkn-wcip-subscription-product', true );
-            if (get_option("lkn_wcip_subscription_active_product_invoices") || 'on' == $is_subscription_enabled) {
+            if (get_option("lkn_wcip_subscription_active_product_invoices") || 'on' == $is_subscription_enabled || $manualSubscription) {
                 $is_subscription_manual = $order->get_meta('lkn_wcip_subscription_is_manual');
                 $iniDate = new DateTime();
                 $iniDateFormatted = $iniDate->format('Y-m-d');
@@ -332,7 +332,7 @@ final class WcPaymentInvoiceSubscription {
                         if ("generate_invoice_event" === $hook || 'lkn_wcip_cron_hook' === $hook) {
                             // Verifique se os argumentos do evento contêm o ID da ordem que você deseja remover
                             $event_args = $event['args'];
-                            if (is_array($event_args) && in_array($order_id, $event_args, true)) {
+                            if (is_array($event_args) && in_array($order_id, $event_args)) {
                                 // Remova o evento do WP Cron
                                 wp_unschedule_event($timestamp, $hook, $event_args);
                             }
@@ -344,12 +344,12 @@ final class WcPaymentInvoiceSubscription {
         }
         $order->update_meta_data('lkn_wcip_subscription_initial_limit', $initialLimit + 1);
         
-        $customer_id = $order->get_customer_id();
+        $customerId = $order->get_customer_id();
         $billing_email = $order->get_billing_email();
         $billing_country = $order->get_billing_country();
         $billing_first_name = $order->get_billing_first_name();
         $billing_last_name = $order->get_billing_last_name();
-        $payment_method = $order->get_payment_method();
+        $paymentMethod = $order->get_payment_method();
         $time_removed = $order->get_meta('lkn_time_removed');
         $iniDate = new DateTime();
         $iniDateFormatted = $iniDate->format('Y-m-d');
@@ -359,20 +359,20 @@ final class WcPaymentInvoiceSubscription {
 
         $new_order = wc_create_order( array(
             'status' => 'wc-pending',
-            'customer_id' => $customer_id,
+            'customerId' => $customerId,
         ) );
         $new_order->set_billing_country($billing_country);
         $new_order->set_billing_first_name($billing_first_name);
         $new_order->set_billing_last_name($billing_last_name);
         $new_order->set_billing_email($billing_email);
-        $new_order->set_payment_method($payment_method);
+        $new_order->set_payment_method($paymentMethod);
         $new_order->add_meta_data('lkn_ini_date', $iniDateFormatted);
         $new_order->add_meta_data('lkn_exp_date', $expDateFormatted);
         $new_order->add_meta_data('lkn_is_subscription', false);
         //ID da assinatura que criou essa fatura
         $new_order->add_meta_data('lkn_subscription_id', $order_id);
         $new_order->add_meta_data('lkn_current_limit', $initialLimit + 1);
-        $new_order_id = $new_order->get_id();
+        $newOrderId = $new_order->get_id();
 
         if ( ! $new_order ) {
             return;
@@ -395,10 +395,29 @@ final class WcPaymentInvoiceSubscription {
 
         //Atualiza data de expiração e id da assinatura para nova data de expiração da fatura gerada 
         $order->update_meta_data('lkn_exp_date', $expDateFormatted);
-        $order->update_meta_data('lkn_invoice_id', $new_order_id);
+        $order->update_meta_data('lkn_invoice_id', $newOrderId);
         $order->save();
 
         $new_order->save();
+
+        // Chama o método de processamento de assinatura
+        if ($paymentMethod != 'multiplePayment' && $customerId != 0) {
+            $subscriptionResult = apply_filters('lkn_process_subscription_' . $paymentMethod, $newOrderId, $customerId, false);
+        
+            $status = isset($subscriptionResult['status']) ? $subscriptionResult['status'] : false;
+            $makeRetry = isset($subscriptionResult['makeRetry']) ? $subscriptionResult['makeRetry'] : false;
+            $nextCronHours = isset($subscriptionResult['nextCronHours']) ? $subscriptionResult['nextCronHours'] : 0;
+        
+            if($status == true){
+                $new_order->payment_complete();
+            }
+
+            if ($status == false && $makeRetry == true) {
+                if ($nextCronHours > 0) {
+                    wp_schedule_single_event(time() + ($nextCronHours * 3600), 'lkn_process_subscription_' . $paymentMethod, array($newOrderId, $customerId, true));
+                }
+            }
+        }
 
         // Adicionar a nova ordem à lista de faturas
         $invoice_list = get_option( 'lkn_wcip_invoices', array() );

--- a/Includes/WcPaymentInvoiceSubscription.php
+++ b/Includes/WcPaymentInvoiceSubscription.php
@@ -346,6 +346,15 @@ final class WcPaymentInvoiceSubscription {
         
         $customerId = $order->get_customer_id();
         $billing_email = $order->get_billing_email();
+        $user = get_user_by('email', $billing_email);
+
+        if ($user) {
+            $user_id = $user->ID; // Obtém o ID do usuário
+            $customerId = $user_id;
+            $order->set_customer_id($customerId);
+            $order->save();
+        }
+
         $billing_country = $order->get_billing_country();
         $billing_first_name = $order->get_billing_first_name();
         $billing_last_name = $order->get_billing_last_name();
@@ -362,6 +371,7 @@ final class WcPaymentInvoiceSubscription {
             'customerId' => $customerId,
         ) );
         $new_order->set_billing_country($billing_country);
+        $new_order->set_customer_id($customerId);
         $new_order->set_billing_first_name($billing_first_name);
         $new_order->set_billing_last_name($billing_last_name);
         $new_order->set_billing_email($billing_email);

--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://www.linknacional.com/wordpress/plugins/
 Tags: woocommerce, invoice, payment
 Requires at least: 5.7
 Tested up to: 6.7
-Stable tag: 2.2.1
+Stable tag: 2.3.0
 Requires PHP: 7.2
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -93,6 +93,11 @@ The Invoice Payment for WooCommerce plugin is now live and working.
 6. Edit details of your subscription.
 
 == Changelog ==
+= 2.3.0 = *02/14/2024*
+* Add field to search for user email;
+* Add hook to process subscription automatically;
+* Add function to force customer registration at checkout.
+
 = 2.2.1 = *31/01/2024*
 * Compatibility fix with the "Payment Gateway Based Fees for WooCommerce" plugin;
 * Updating plugin description link.

--- a/languages/wc-invoice-payment-pt_BR.po
+++ b/languages/wc-invoice-payment-pt_BR.po
@@ -296,11 +296,11 @@ msgstr "Criar usuário"
 msgid "Feature available for registered user."
 msgstr "Recurso disponivel para usuário cadastrados"
 
-msgid "If the multiple payments option is selected, automatic recurring payments will be disabled."
-msgstr "Se a opção de pagamentos múltiplos estiver selecionada, os pagamentos recorrentes automáticos estarão desabilitados."
+msgid "To automate charges, choose a compatible payment method (e.g., Cielo Pro Plugin). If multiple payments are selected, the charge will not be automatic."
+msgstr "Para automatizar as cobranças selecione um meio de pagamento com essa capacidade (ex.: Plugin Cielo Pro). Ao marcar pagamentos múltiplos a cobrança não será automática."
 
-msgid "If the assigned user is a guest, automatic recurring payments will be disabled."
-msgstr "Se o usuário atribuído for um visitante, os pagamentos recorrentes automáticos estarão desabilitados."
+msgid "Select a user to generate subscriptions. Guests cannot process automatic charges."
+msgstr "Selecione um usuário para gerar assinaturas. Visitantes não tem capacidade para cobranças automáticas."
 
 msgid "Customer"
 msgstr "Cliente"

--- a/languages/wc-invoice-payment-pt_BR.po
+++ b/languages/wc-invoice-payment-pt_BR.po
@@ -295,3 +295,9 @@ msgstr "Criar usuário"
 
 msgid "Feature available for registered user."
 msgstr "Recurso disponivel para usuário cadastrados"
+
+msgid "If the multiple payments option is selected, automatic recurring payments will be disabled."
+msgstr "Se a opção de pagamentos múltiplos estiver selecionada, os pagamentos recorrentes automáticos estarão desabilitados."
+
+msgid "If the assigned user is a guest, automatic recurring payments will be disabled."
+msgstr "Se o usuário atribuído for um visitante, os pagamentos recorrentes automáticos estarão desabilitados."

--- a/languages/wc-invoice-payment-pt_BR.po
+++ b/languages/wc-invoice-payment-pt_BR.po
@@ -301,3 +301,6 @@ msgstr "Se a opção de pagamentos múltiplos estiver selecionada, os pagamentos
 
 msgid "If the assigned user is a guest, automatic recurring payments will be disabled."
 msgstr "Se o usuário atribuído for um visitante, os pagamentos recorrentes automáticos estarão desabilitados."
+
+msgid "Customer"
+msgstr "Cliente"

--- a/languages/wc-invoice-payment-pt_BR.po
+++ b/languages/wc-invoice-payment-pt_BR.po
@@ -292,3 +292,6 @@ msgstr "Recurso disponivel para usuário cadastrado"
 
 msgid "Create user"
 msgstr "Criar usuário"
+
+msgid "Feature available for registered user."
+msgstr "Recurso disponivel para usuário cadastrados"

--- a/languages/wc-invoice-payment-pt_BR.po
+++ b/languages/wc-invoice-payment-pt_BR.po
@@ -286,3 +286,9 @@ msgstr "Idioma do PDF da fatura"
 
 msgid "To add other languages, install the language in your WordPress."
 msgstr "Para adicionar outros idiomas, instale o idioma em seu Wordpress."
+
+msgid "Feature available for registered user"
+msgstr "Recurso disponivel para usuário cadastrado"
+
+msgid "Create user"
+msgstr "Criar usuário"

--- a/languages/wc-invoice-payment.pot
+++ b/languages/wc-invoice-payment.pot
@@ -289,3 +289,9 @@ msgstr ""
 
 msgid "Feature available for registered user."
 msgstr ""
+
+msgid "If the multiple payments option is selected, automatic recurring payments will be disabled."
+msgstr ""
+
+msgid "If the assigned user is a guest, automatic recurring payments will be disabled."
+msgstr ""

--- a/languages/wc-invoice-payment.pot
+++ b/languages/wc-invoice-payment.pot
@@ -290,10 +290,10 @@ msgstr ""
 msgid "Feature available for registered user."
 msgstr ""
 
-msgid "If the multiple payments option is selected, automatic recurring payments will be disabled."
+msgid "To automate charges, choose a compatible payment method (e.g., Cielo Pro Plugin). If multiple payments are selected, the charge will not be automatic."
 msgstr ""
 
-msgid "If the assigned user is a guest, automatic recurring payments will be disabled."
+msgid "Select a user to generate subscriptions. Guests cannot process automatic charges."
 msgstr ""
 
 msgid "Customer"

--- a/languages/wc-invoice-payment.pot
+++ b/languages/wc-invoice-payment.pot
@@ -280,3 +280,9 @@ msgstr ""
 
 msgid "To add other languages, install the language in your WordPress."
 msgstr ""
+
+msgid "Feature available for registered user"
+msgstr ""
+
+msgid "Create user"
+msgstr ""

--- a/languages/wc-invoice-payment.pot
+++ b/languages/wc-invoice-payment.pot
@@ -286,3 +286,6 @@ msgstr ""
 
 msgid "Create user"
 msgstr ""
+
+msgid "Feature available for registered user."
+msgstr ""

--- a/languages/wc-invoice-payment.pot
+++ b/languages/wc-invoice-payment.pot
@@ -295,3 +295,6 @@ msgstr ""
 
 msgid "If the assigned user is a guest, automatic recurring payments will be disabled."
 msgstr ""
+
+msgid "Customer"
+msgstr ""

--- a/wc-invoice-payment.php
+++ b/wc-invoice-payment.php
@@ -15,7 +15,7 @@
  * Plugin Name:       Invoice Payment for WooCommerce
  * Plugin URI:        https://www.linknacional.com/wordpress/plugins/
  * Description:       Invoice payment generation and management for WooCommerce.
- * Version:           2.2.1
+ * Version:           2.3.0
  * Author:            Link Nacional
  * Author URI:        https://www.linknacional.com/
  * Requires Plugins: woocommerce
@@ -41,7 +41,7 @@ require_once __DIR__ . '/vendor/autoload.php';
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define('WC_PAYMENT_INVOICE_VERSION', '2.2.1');
+define('WC_PAYMENT_INVOICE_VERSION', '2.3.0');
 define('WC_PAYMENT_INVOICE_TRANSLATION_PATH', plugin_dir_path(__FILE__) . 'languages/');
 define('WC_PAYMENT_INVOICE_ROOT_DIR', plugin_dir_path(__FILE__));
 define('WC_PAYMENT_INVOICE_ROOT_URL', plugin_dir_url(__FILE__));


### PR DESCRIPTION
- Adição de campo para pesquisar email do usuário;
> Foi adicionado um campo para buscar e associar um usuário a uma assinatura ou fatura. Caso a assinatura não tenha um usuário vinculado, os pagamentos recorrentes automáticos permanecerão desativados.
![image](https://github.com/user-attachments/assets/8135323b-480f-4c86-b851-fd0570576a8b)

- Adição de hook para processar assinatura automaticamente;
>Foi adicionado um novo hook para permitir que métodos de pagamento adicionem compatibilidade com pagamentos recorrentes automáticos. (Mais informações sobre o hook no [README.md](https://github.com/LinkNacional/woocommerce-invoice-payment/blob/dev/README.md#how-to-integrate-with-subscription-processing))

- Adição de função para forçar registro do cliente no checkout.
> Foi implementada uma função que exige o login ou registro do cliente no checkout quando o carrinho contém um produto com assinatura ativada.
